### PR TITLE
Adding initial intermediate models

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -43,11 +43,11 @@ models:
       +persist_docs:
         relation:  true
         columns: true
-    #intermediate:
-    #  +materialized: view
-     # +persist_docs: 
-     #   relation: true
-      #  columns: true
+    intermediate:
+      +materialized: view
+      +persist_docs: 
+        relation: true
+        columns: true
         
     #mart:
      # +materialized: table

--- a/models/intermediate/int_orders.sql
+++ b/models/intermediate/int_orders.sql
@@ -1,0 +1,28 @@
+WITH order_item_grouped_by_order AS(
+    SELECT order_id,
+            sum(discount_amount) AS total_order_discount,
+            sum(total_order_item_price) AS total_order_amount,
+            sum(quantity) AS total_items,
+            count(distinct(product_id)) AS total_distinct_items,
+FROM {{ref('stg_order_items')}}
+GROUP BY order_id
+)
+
+
+SELECT
+    o.order_id,
+    o.customer_id,
+    o.order_status,
+    o.order_date,
+    o.store_id,
+    o.staff_id,
+    c.customer_city,
+    c.customer_state,
+    coalesce(oi.total_order_amount,0) AS total_order_amount,
+    coalesce(oi.total_order_discount,0) AS total_order_discount,
+    coalesce(oi.total_items,0) AS total_items,
+    coalesce(oi.total_distinct_items,0) AS total_distinct_items
+FROM {{ref('stg_orders')}} AS o
+left join {{ref('stg_customers')}} AS c ON o.customer_id = c.customer_id
+left join order_item_grouped_by_order AS oi ON o.order_id= oi.order_id
+

--- a/models/intermediate/int_products.sql
+++ b/models/intermediate/int_products.sql
@@ -1,0 +1,24 @@
+ WITH sales_by_product AS
+ (SELECT product_id,
+           sum(quantity) AS total_product_sold,
+           sum(total_order_item_price) AS total_amount,
+           avg(percentage_discount) AS average_discount
+FROM {{ref("stg_order_items")}}
+GROUP BY product_id
+)
+
+SELECT p.product_id,
+       p.product_name,
+       p.brand_id,
+       b.brand_name,
+       c.category_id,
+       c.category_name,
+       coalesce(sp.total_product_sold,0) AS total_product_sold,
+       coalesce(sp.total_amount,0) AS total_sales_amount,
+       coalesce(sp.average_discount,0) AS average_discount_on_product,
+FROM {{ref('stg_products')}} AS p
+left join sales_by_product AS sp on p.product_id = sp.product_id
+left join {{ref('stg_brands')}} AS b on p.brand_id = b.brand_id
+left join {{ref("stg_categories")}} AS c on p.category_id = c.category_id
+
+       

--- a/models/intermediate/int_staff.sql
+++ b/models/intermediate/int_staff.sql
@@ -1,0 +1,9 @@
+--WITH staff_summary as(
+   -- SELECT staff_id,
+          -- sum(quantity) as total_products_sold,
+          -- sum(distinct())
+         --  sum(total_order_item_price) as total_amount_sold,
+          -- avg(percentage_discount) as average_staff_discount,
+
+
+--)

--- a/models/staging/stg_customers.sql
+++ b/models/staging/stg_customers.sql
@@ -1,6 +1,6 @@
 SELECT customer_id,
        concat(first_name,' ',last_name) AS customer_name,
-       cast(phone AS varchar(15)) AS customer_phone_number,
+       phone AS customer_phone_number,
        email AS customer_email,
        street as customer_street,
        city as customer_city,

--- a/models/staging/stg_order_items.sql
+++ b/models/staging/stg_order_items.sql
@@ -1,9 +1,14 @@
-SELECT concat(order_id,'_',item_id) AS order_item_id,
-        order_id,
-        item_id,
-        product_id,
-        quantity,
-        cast(list_price AS numeric) AS list_price,
-        (discount*100) AS percentage_discount,
-        {{order_item_price_after_discount('list_price','discount','quantity')}} AS total_order_item_price
-FROM {{source('local_bike','order_items')}}
+select
+    concat(order_id, '_', item_id) as order_item_id,
+    order_id,
+    item_id,
+    product_id,
+    quantity,
+    cast(list_price as decimal) as list_price,
+    (discount * 100) as percentage_discount,
+    cast((list_price * discount) as decimal) as discount_amount,
+    cast(
+        {{ order_item_price_after_discount("list_price", "discount", "quantity") }}
+        as decimal
+    ) as total_order_item_price
+from {{ source("local_bike", "order_items") }}


### PR DESCRIPTION
Cleaned up staging files with better datatypes. Added two intermediate models for orders and products. Orders model groups by order, calculates discounts and total amoounts. Products model looks at number of a product sold, average discount and total value sold. 